### PR TITLE
Make scrollable area adjustable

### DIFF
--- a/app/imports/ui/components/ResponseChatItem.jsx
+++ b/app/imports/ui/components/ResponseChatItem.jsx
@@ -1,19 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const ChatItem = ({ content, role, sources, titles }) => {
-  const userBackgroundColor = 'gray';
-  const assistantBackgroundColor = 'green';
-
+const ResponseChatItem = ({ content, sources, titles }) => {
   const containerStyle = {
-    backgroundColor: role === 'user' ? userBackgroundColor : assistantBackgroundColor,
+    backgroundColor: 'green',
     color: 'white',
     padding: '10px',
     marginBottom: '10px',
     borderRadius: '5px',
-    overflowY: 'auto', // Enable vertical scrolling
-    maxHeight: '200px', // Adjust the maximum height as needed
+    overflow: 'auto',
+    maxHeight: '300px', // Adjust the maximum height as needed
     boxShadow: '0px 7px 8px rgba(0, 0, 0, 0.1)',
+    resize: 'vertical', // Enable vertical resizing only
+    minWidth: '100px',
+    minHeight: '100px',
   };
 
   const sourceContainerStyle = {
@@ -46,10 +46,10 @@ const ChatItem = ({ content, role, sources, titles }) => {
   ));
   return (
     <div>
-      <div style={containerStyle}>
+      <div style={containerStyle} contentEditable="true">
         {content}
       </div>
-      {haveSources() && role === 'assistant' && (
+      {haveSources() && (
         <div className="body.dark-sources" style={sourceContainerStyle}>
           <ul className="pt-3">
             Related Article Links:
@@ -62,13 +62,12 @@ const ChatItem = ({ content, role, sources, titles }) => {
 };
 
 // Require a document to be passed to this component.
-ChatItem.propTypes = {
+ResponseChatItem.propTypes = {
   content: PropTypes.string.isRequired,
-  role: PropTypes.oneOf(['user', 'assistant']).isRequired,
   // eslint-disable-next-line react/require-default-props
   sources: PropTypes.arrayOf(PropTypes.string),
   // eslint-disable-next-line react/require-default-props
   titles: PropTypes.arrayOf(PropTypes.string),
 };
 
-export default ChatItem;
+export default ResponseChatItem;

--- a/app/imports/ui/components/ResponseChatItem.jsx
+++ b/app/imports/ui/components/ResponseChatItem.jsx
@@ -13,7 +13,7 @@ const ResponseChatItem = ({ content, sources, titles }) => {
     boxShadow: '0px 7px 8px rgba(0, 0, 0, 0.1)',
     resize: 'vertical', // Enable vertical resizing only
     minWidth: '100px',
-    minHeight: '100px',
+    minHeight: '50px',
   };
 
   const sourceContainerStyle = {

--- a/app/imports/ui/components/Search.jsx
+++ b/app/imports/ui/components/Search.jsx
@@ -2,8 +2,9 @@ import { Col, Container, Form, InputGroup, Row, Button } from 'react-bootstrap';
 import { Search } from 'react-bootstrap-icons';
 import React, { useState } from 'react';
 import { Meteor } from 'meteor/meteor';
-import ChatItem from './ChatItem';
+import ResponseChatItem from './ResponseChatItem';
 import LoadingSpinner from './LoadingSpinner';
+import UserChatItem from './UserChatItem';
 
 const ITSearch = () => {
   const [userInput, setUserInput] = useState('');
@@ -90,9 +91,11 @@ const ITSearch = () => {
         </Col>
         <Col xs={8} className="d-flex flex-column justify-content-start">
           {chatMessages.map((chat, index) => (
+            // eslint-disable-next-line no-nested-ternary
             chat.isLoading ?
-              <LoadingSpinner key={index} /> :
-              <ChatItem content={chat.content} role={chat.role} sources={chat.sources} titles={chat.titles} key={index} />
+              <LoadingSpinner key={index} /> : chat.role === 'user' ?
+                <UserChatItem content={chat.content} key={index} /> :
+                <ResponseChatItem content={chat.content} sources={chat.sources} titles={chat.titles} key={index} />
           ))}
         </Col>
       </Row>

--- a/app/imports/ui/components/Search.jsx
+++ b/app/imports/ui/components/Search.jsx
@@ -101,8 +101,9 @@ const ITSearch = () => {
           {chatMessages.map((chat, index) => (
             // eslint-disable-next-line no-nested-ternary
             chat.isLoading ?
-              <LoadingSpinner key={index} /> :
-              <ChatItem content={chat.content} role={chat.role} sources={chat.sources} titles={chat.titles} scores={chat.scores} key={index} />
+              <LoadingSpinner key={index} /> : chat.role === 'user' ?
+                <UserChatItem content={chat.content} key={index} /> :
+                <ResponseChatItem content={chat.content} sources={chat.sources} titles={chat.titles} scores={chat.scores} key={index} />
           ))}
         </Col>
       </Row>

--- a/app/imports/ui/components/UserChatItem.jsx
+++ b/app/imports/ui/components/UserChatItem.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const UserChatItem = ({ content }) => {
+  const containerStyle = {
+    backgroundColor: 'gray',
+    color: 'white',
+    padding: '10px',
+    marginBottom: '10px',
+    borderRadius: '5px',
+    overflowY: 'auto',
+    maxHeight: '200px',
+    boxShadow: '0px 7px 8px rgba(0, 0, 0, 0.1)',
+  };
+  return (
+    <div>
+      <div style={containerStyle} contentEditable="true">
+        {content}
+      </div>
+    </div>
+  );
+};
+
+// Require a document to be passed to this component.
+UserChatItem.propTypes = {
+  content: PropTypes.string.isRequired,
+};
+
+export default UserChatItem;


### PR DESCRIPTION
- Separate response and user chats
- Add scroll-ability

Separated the chat components because I thought it wouldn't be necessary to include the links (and other response-related info) for the user's input.

Allows users to customize the response area size. However, there is a cap of 300px and then the user would need to scroll if it goes past that max height. Only did this because I couldn't figure out a way to make the max height relevant to the content itself.